### PR TITLE
feat: Mocha test linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,14 @@ Earnest's ESLint config for ES7
     ```
 
 6. (Recommended) Setup your editor to support inline ESLint support. For Sublime Text, that means `npm install -g eslint` then installing `SublimeLinter` and `SublimeLinter-contrib-eslint` packages. For Vim, use [Syntastic](https://github.com/scrooloose/syntastic).
+
+## Linting this Repository
+
+In order to run linting against this repository, you must create a self-referential link to this module:
+ 
+ ```
+ npm install
+ npm link
+ npm link eslint-config-earnest-es7
+ npm run lint
+ ```

--- a/README.md
+++ b/README.md
@@ -14,15 +14,14 @@ Earnest's ESLint config for ES7
 3. Add a root level `.eslintrc` that references this package
 
     ```json
-    { "extends": "earnest" }
+    { "extends": "earnest-es7" }
     ```
 
 4. Add another `.eslintrc` to your `test` folder that supports mocha
 
     ```json
     {
-      "extends": "earnest",
-      "env": { "mocha": true }
+      "extends": "earnest-es7/mocha"
     }
     ```
 

--- a/mocha.js
+++ b/mocha.js
@@ -1,0 +1,6 @@
+module.exports = {
+  "extends": "earnest-es7",
+  "env": {
+    "mocha": true
+  }
+};

--- a/mocha.js
+++ b/mocha.js
@@ -1,6 +1,12 @@
 module.exports = {
   "extends": "earnest-es7",
+  "plugins": [
+    "mocha"
+  ],
   "env": {
     "mocha": true
+  },
+  "rules": {
+    "mocha/no-exclusive-tests": 2
   }
 };

--- a/package.json
+++ b/package.json
@@ -30,13 +30,14 @@
   },
   "homepage": "https://github.com/meetearnest/eslint-config-earnest-es7",
   "devDependencies": {
-    "babel-core": "^6.3.26",
     "babel-cli": "^6.3.17",
+    "babel-core": "^6.3.26",
     "babel-eslint": "^5.0.0-beta6",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-3": "^6.3.13",
     "eslint": "^1.10.3",
     "eslint-plugin-babel": "^3.0.0",
+    "eslint-plugin-mocha": "^1.1.0",
     "mocha": "^2.3.4"
   },
   "peerDependencies": {
@@ -45,6 +46,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-3": "^6.3.13",
     "eslint": "^1.10.3",
-    "eslint-plugin-babel": "^3.0.0"
+    "eslint-plugin-babel": "^3.0.0",
+    "eslint-plugin-mocha": "^1.1.0"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,6 +1,3 @@
 {
-  "extends": "earnest-es7",
-  "env": {
-    "mocha": true
-  }
+  "extends": "earnest-es7/mocha"
 }

--- a/test/linting.spec.js
+++ b/test/linting.spec.js
@@ -1,24 +1,23 @@
-import { CLIEngine } from 'eslint'
-import { execSync } from 'child_process'
+import {execSync} from 'child_process';
 
 describe('Linting', () => {
   describe('Exemplar - Bittorrent DHT Client in Earnest Style', () => {
     it('passes linting', () => {
-      var res = eslint(`${__dirname}/data/bittorrent-dht-client.js`)
-      if (res) throw new Error(res)
-    })
-  })
+      const res = eslint(`${__dirname}/data/bittorrent-dht-client.js`);
+      if (res) throw new Error(res);
+    });
+  });
 
   describe('Linting Rules Config', () => {
     it('passes linting', () => {
-      var res = eslint(`${__dirname}/../index.js`)
-      if (res) throw new Error(res)
-    })
-  })
-})
+      const res = eslint(`${__dirname}/../index.js`);
+      if (res) throw new Error(res);
+    });
+  });
+});
 
-function eslint (path) {
-  const command = './node_modules/.bin/eslint --no-eslintrc -c index.js ' + path
-  const opts = { cwd: __dirname + '/..', encoding: 'utf8' }
-  try { return execSync(command, opts) } catch (ex) { return ex.stdout }
+function eslint(path) {
+  const command = './node_modules/.bin/eslint --no-eslintrc -c index.js ' + path;
+  const opts = {cwd: __dirname + '/..', encoding: 'utf8'};
+  try { return execSync(command, opts); } catch (ex) { return ex.stdout; }
 }


### PR DESCRIPTION
Adds support for a secondary lint config for mocha folders. 
This includes the env settings and a requirement for the 
exclusive test linter plugin.

Also updated documentation for how to use this.