### PR TITLE
feat: Switch to scoped module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,20 @@ Earnest's ESLint config for ES7
 1. Install the following `"devDependencies"` in your repo:
 
     ```
-    npm install eslint-config-earnest-es7@latest babel-core babel-cli babel-eslint babel-preset-es2015 babel-preset-stage-3 eslint eslint-plugin-babel --save-dev
+    npm install @earnest/eslint-config-es7@latest babel-core babel-cli babel-eslint babel-preset-es2015 babel-preset-stage-3 eslint eslint-plugin-babel --save-dev
     ```
 
 2. Add a root level `.eslintrc` that references this package
 
     ```
-    echo '{ "extends": "earnest-es7" }' > .eslintrc
+    echo '{ "extends": "@earnest/eslint-config-es7" }' > .eslintrc
     ```
 
 3. Add another `.eslintrc` to your `test` folder that supports mocha
-
+  
     ```
-    echo '{\n\s\s"extends": "earnest-es7"\n}' > test/.eslintrc
+    npm install eslint-plugin-mocha --save-dev
+    echo '{ "extends": "@earnest/eslint-config-es7/mocha" }' > test/.eslintrc
     ```
 
 4. (Recommended) Add the following entries to your `package.json` for simplified CLI access to linting:
@@ -39,6 +40,6 @@ In order to run linting against this repository, you must create a self-referent
  ```
  npm install
  npm link
- npm link eslint-config-earnest-es7
+ npm link @earnest/eslint-config-es7
  npm run lint
  ```

--- a/mocha.js
+++ b/mocha.js
@@ -1,5 +1,5 @@
 module.exports = {
-  "extends": "earnest-es7",
+  "extends": "@earnest/eslint-config-es7",
   "plugins": [
     "mocha"
   ],

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "eslint-config-earnest-es7",
+  "name": "@earnest/eslint-config-es7",
   "version": "3.0.1",
   "description": "Earnest's ESLint config for ES7",
   "main": "index.js",
   "scripts": {
     "lint": "./node_modules/.bin/eslint .",
-    "test": "./node_modules/.bin/mocha --compilers js:babel-core/register",
+    "test": "./node_modules/.bin/mocha --timeout 5000 --compilers js:babel-core/register",
     "preversion": "npm test",
     "postversion": "git push && git push --tags && npm publish"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earnest/eslint-config-es7",
-  "version": "3.0.1",
+  "version": "1.0.0",
   "description": "Earnest's ESLint config for ES7",
   "main": "index.js",
   "scripts": {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "earnest-es7/mocha"
+  "extends": "@earnest/eslint-config-es7/mocha"
 }


### PR DESCRIPTION
This PR switches the repo to use a scoped NPM module. The motivation
for this change is to simplify management of collaborators for
publishing.

Upon merge, a new *public* scoped NPM module would be published.

Tested and confirmed working in another repo.

Question: Is this a major version bump? It's not an API change.