### PR TITLE
Set arrow-body-style to 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = {
 /**
  * ES6+
  */
-    "arrow-body-style": 2,
+    "arrow-body-style": 0,
     "arrow-spacing": 2,
     "constructor-super": 2,
     "no-confusing-arrow": 2,


### PR DESCRIPTION
`arrow-body-style` is a confusing and troublesome rule, especially for Promise chains. We are setting the rule to 0. It is the developer's choice whether or not to use braces when surrounding arrow-bodes.

@jhurliman 