### PR TITLE
fix babel linter deprecated warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,13 +45,11 @@ module.exports = {
 /**
  * eslint-plugin-babel rule toggles
  */
-    "babel/generator-star-spacing": [2, "after"],
     "babel/new-cap": 0,
     "babel/array-bracket-spacing": 0,
     "babel/object-curly-spacing": 0,
     "babel/object-shorthand": 0,
     "babel/arrow-parens": 0,
-    "babel/no-await-in-loop": 2,
 
 /**
  * ES6+
@@ -59,6 +57,8 @@ module.exports = {
     "arrow-body-style": 0,
     "arrow-spacing": 2,
     "constructor-super": 2,
+    "generator-star-spacing": [2, "after"],
+    "no-await-in-loop": 2,
     "no-confusing-arrow": 2,
     "no-class-assign": 2,
     "no-const-assign": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earnest/eslint-config-es7",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Earnest's ESLint config for ES7",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Update linter to use native and non-deprecated rules
Resolves this deprecation warning from babel.

```log
The babel/generator-star-spacing rule is deprecated. Please use the built in generator-star-spacing rule instead.
The babel/no-await-in-loop rule is deprecated. Please use the built in no-await-in-loop rule instead.
```