### PR TITLE
Update peer dependencies

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Earnest, Inc.
+Copyright (c) 2017 Earnest, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # eslint-config-earnest-es7
+
 Earnest's ESLint config for ES7
 
 ## Usage
@@ -12,31 +13,39 @@ Earnest's ESLint config for ES7
 2. Add a root level `.eslintrc` that references this package
 
     ```
-    echo '{ "extends": "@earnest/eslint-config-es7" }' > .eslintrc
+    echo '{"extends": "@earnest/eslint-config-es7"}' > .eslintrc
+    ```
+
+    Alternatively add this entry to your `package.json`:
+
+    ```json
+    "eslintConfig": {
+      "extends": "@earnest/eslint-config-es7"
+    }
     ```
 
 3. Add another `.eslintrc` to your `test` folder that supports mocha
-  
+
     ```
     npm install eslint-plugin-mocha --save-dev
-    echo '{ "extends": "@earnest/eslint-config-es7/mocha" }' > test/.eslintrc
+    echo '{"extends": "@earnest/eslint-config-es7/mocha"}' > test/.eslintrc
     ```
 
 4. (Recommended) Add the following entries to your `package.json` for simplified CLI access to linting:
 
     ```json
     "scripts": {
-      "lint": "./node_modules/.bin/eslint .",
+      "lint": "eslint .",
       "lint-changed": "git diff --name-only --cached --relative | grep '\\.js$' | xargs ./node_modules/.bin/eslint"
     }
     ```
 
-5. (Recommended) Setup your editor to support inline ESLint support. For Sublime Text, that means `npm install -g eslint` then installing `SublimeLinter` and `SublimeLinter-contrib-eslint` packages. For Vim, use [Syntastic](https://github.com/scrooloose/syntastic).
+5. (Recommended) Setup your editor to support inline ESLint support. For Sublime Text, that means `npm install --global eslint` then installing `SublimeLinter` and `SublimeLinter-contrib-eslint` packages. For Vim, use [Syntastic](https://github.com/scrooloose/syntastic).
 
 ## Linting this Repository
 
 In order to run linting against this repository, you must create a self-referential link to this module:
- 
+
  ```
  npm install
  npm link

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earnest/eslint-config-es7",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Earnest's ESLint config for ES7",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Earnest's ESLint config for ES7",
   "main": "index.js",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint .",
-    "test": "./node_modules/.bin/mocha --timeout 5000 --compilers js:babel-core/register"
+    "test": "mocha --timeout 5000 --compilers js:babel-core/register"
   },
   "repository": {
     "type": "git",
@@ -30,21 +29,21 @@
   "devDependencies": {
     "babel-cli": "^6.11.4",
     "babel-core": "^6.11.4",
-    "babel-eslint": "^6.1.2",
+    "babel-eslint": "^7.2.2",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-3": "^6.11.0",
-    "eslint": "^3.1.1",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^3.19.0",
+    "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-mocha": "^4.0.0",
     "mocha": "^2.5.3"
   },
   "peerDependencies": {
     "babel-core": "^6.11.4",
-    "babel-eslint": "^6.1.2",
+    "babel-eslint": "^7.2.2",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-3": "^6.11.0",
     "eslint-plugin-mocha": "^4.0.0",
-    "eslint-plugin-babel": "^3.0.0",
-    "eslint": "^3.1.1"
+    "eslint-plugin-babel": "^4.1.1",
+    "eslint": "^3.19.0"
   }
 }

--- a/scripts/ci/publish
+++ b/scripts/ci/publish
@@ -3,7 +3,6 @@
 set -euo pipefail
 : ${SNAP_CI?This script is designed to be run within SnapCI. Aborting in a cowardly fashion.}
 
-
 # Login to NPM
 npmrc_contents="//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
 echo $npmrc_contents > "${HOME}/.npmrc"


### PR DESCRIPTION
Update peer dependencies

The peer dependencies were out of date.  Meaning that users of this module could get in a state where they were experiencing weird errors, but weren't told that their dependencies didn't align with what this repo requires.  This commit resolves that issue.

For more information on the specific issue most folks were facing see: here: https://github.com/eslint/eslint/issues/7012

Updating the peer dependency `babel-eslint` to v7 or greater fixed this issue.

Resolves: https://meetearnest.atlassian.net/browse/PLAT-663

For proof that it works if you use the latest linter with the updated peer dependencies expand the Details section below.

<details>

```fish
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
➜  ~ j analyze
/Users/jesseatkinson/Developer/analyze-api
➜  analyze-api git:(master) vim
➜  analyze-api git:(master) git branch
  jsatk-PLAT-740
  jsatk-PLAT-740-part-two
  jsatk-fix-linter-woes
  jsatk-fix-string-issue
* master
➜  analyze-api git:(master) git checkout jsatk-fix-linter-woes
Switched to branch 'jsatk-fix-linter-woes'
Your branch is up-to-date with 'origin/jsatk-fix-linter-woes'.
➜  analyze-api git:(jsatk-fix-linter-woes) vim
➜  analyze-api git:(jsatk-fix-linter-woes) ✗ ./go
Starting analyzeapi_node-modules_1
npm info it worked if it ends with ok
npm info using npm@3.8.6
npm info using node@v6.1.0
npm info attempt registry request try #1 at 8:54:37 PM
npm http request GET https://registry.npmjs.org/fsevents
npm http 200 https://registry.npmjs.org/fsevents
npm info lifecycle analyze-api@1.0.0~preinstall: analyze-api@1.0.0
npm info linkStuff analyze-api@1.0.0
npm info lifecycle analyze-api@1.0.0~install: analyze-api@1.0.0
npm info lifecycle analyze-api@1.0.0~postinstall: analyze-api@1.0.0
npm info lifecycle analyze-api@1.0.0~prepublish: analyze-api@1.0.0
npm WARN optional Skipping failed optional dependency /chokidar/fsevents:
npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.1.1
npm WARN @earnest/eslint-config-es7@4.0.2 requires a peer of eslint-plugin-babel@^4.1.1 but none was installed.
npm WARN chai-enzyme@0.4.2 requires a peer of cheerio@0.19.x || 0.20.x but none was installed.
npm info ok
Usage: ./go <command> [sub-command]

Available commands are:
    migrate [cmd] Run database migrations
        development Run database migrations for dev
        test        Run database migrations for test
        staging     Run database migrations for staging
        production  Run database migrations for production
    load_fixtures [cmd] Loads fixtures
        development Load fixtures for dev
        test        Load fixtures for test
        staging     Load fixtures for staging
        production  Load fixtures for production
    create_migration Create a new correctly timestamped migration
    test [type]     Run tests
       unit         Run unit tests
       smoke [env]  Run smoke tests. Supported [env]: staging, production
    build [type]    Build docker image(s)
       all          Default, build everything
       dev          Build the development image
       prod         Build the production image
    compile         Compile source code
    push            Push docker image to Docker Hub.
       staging      Default, push image with 'latest' and version tag
       production   Push image with 'promoted' tag
    lint            Run lint on code
    deploy [env]    Deploy image from DockerHub via Rundeck
       staging      Deploy to staging
       production   Deploy to production
    start           Start service locally
       dev          Start dev service locally
       prod         Start prod service locally
    login [repo]    Login to service
       npm          Login to npm
       docker       Login to docker
    stop            Stop the local server
    exec            Execute any command inside the dev image
    coveralls       Send coverage report to Coveralls
    nuke            Destroy all containers and images associated with this project, node_modules, and any Babel transpiled code in the dist/ directory.
    help            Shows this help text
➜  analyze-api git:(jsatk-fix-linter-woes) ✗ ./go exec bash
Executing command in container
cat Starting analyzeapi_node-modules_1
^R
root@f6748d781f90:/usr/src/app# jq

jq - commandline JSON processor [version 1.4-1-e73951f]
Usage: jq [options] <jq filter> [file...]

For a description of the command line options and
how to write jq filters (and why you might want to)
see the jq manpage, or the online documentation at
http://stedolan.github.com/jq

root@f6748d781f90:/usr/src/app# cat node_modules/\@earnest/eslint-config-es7/package.json | jq .version
"4.0.2"
root@f6748d781f90:/usr/src/app# exit
exit
➜  analyze-api git:(jsatk-fix-linter-woes) ✗ npm info @earnest/eslint-config-es7 versions
[ '1.0.0', '2.0.0', '2.1.0', '2.1.1', '3.0.0', '3.0.1', '4.0.1' ]
➜  analyze-api git:(jsatk-fix-linter-woes) ✗ ./go lint
Starting analyzeapi_node-modules_1
npm info it worked if it ends with ok
npm info using npm@3.8.6
npm info using node@v6.1.0
npm info lifecycle analyze-api@1.0.0~prelint: analyze-api@1.0.0
npm info lifecycle analyze-api@1.0.0~lint: analyze-api@1.0.0

> analyze-api@1.0.0 lint /usr/src/app
> eslint src test web web-test

npm info lifecycle analyze-api@1.0.0~postlint: analyze-api@1.0.0
npm info ok
➜  analyze-api git:(jsatk-fix-linter-woes) ✗ git diff
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
modified: docker-compose.yml
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
@ docker-compose.yml:6 @ dev:
  entrypoint: ./docker-entrypoint.sh
  volumes:
    - ".:/usr/src/app"
    - "../eslint-config-earnest-es7/index.js:/usr/src/app/node_modules/@earnest/eslint-config-es7/index.js"
    - "../eslint-config-earnest-es7/package.json:/usr/src/app/node_modules/@earnest/eslint-config-es7/package.json"
    - "../eslint-config-earnest-es7/mocha.js:/usr/src/app/node_modules/@earnest/eslint-config-es7/mocha.js"
  ports:
    - "3000:3000"
  links:
➜  analyze-api git:(jsatk-fix-linter-woes) ✗ git stash
gSaved working directory and index state WIP on jsatk-fix-linter-woes: cf30263 Update dev dependencies so that we can use latest version of linter
HEAD is now at cf30263 Update dev dependencies so that we can use latest version of linter
➜  analyze-api git:(jsatk-fix-linter-woes) git checkout master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
➜  analyze-api git:(master) git stash pop
On branch master
Your branch is up-to-date with 'origin/master'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

        modified:   docker-compose.yml

no changes added to commit (use "git add" and/or "git commit -a")
Dropped refs/stash@{0} (9c953deecb141ffe90f8c06a0321689cc9dc7ae7)
➜  analyze-api git:(master) ✗ git stash^C
➜  analyze-api git:(master) ✗ ./go; and ./go exec bash
Starting analyzeapi_node-modules_1
npm info it worked if it ends with ok
npm info using npm@3.8.6
npm info using node@v6.1.0
npm info attempt registry request try #1 at 8:56:10 PM
npm http request GET https://registry.npmjs.org/@earnest%2feslint-config-es7
npm info attempt registry request try #1 at 8:56:10 PM
npm http request GET https://registry.npmjs.org/babel-eslint
npm http 200 https://registry.npmjs.org/@earnest%2feslint-config-es7
npm http 200 https://registry.npmjs.org/babel-eslint
npm info retry fetch attempt 1 at 8:56:10 PM
npm info attempt registry request try #1 at 8:56:10 PM
npm http fetch GET https://registry.npmjs.org/@earnest/eslint-config-es7/-/eslint-config-es7-3.0.0.tgz
npm info retry fetch attempt 1 at 8:56:10 PM
npm info attempt registry request try #1 at 8:56:10 PM
npm http fetch GET https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz
npm http fetch 200 https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz
npm http fetch 200 https://registry.npmjs.org/@earnest/eslint-config-es7/-/eslint-config-es7-3.0.0.tgz
npm info attempt registry request try #1 at 8:56:10 PM
npm http request GET https://registry.npmjs.org/fsevents
npm http 200 https://registry.npmjs.org/fsevents
npm info attempt registry request try #1 at 8:56:11 PM
npm http request GET https://registry.npmjs.org/lodash.pickby
npm http 200 https://registry.npmjs.org/lodash.pickby
npm info retry fetch attempt 1 at 8:56:11 PM
npm info attempt registry request try #1 at 8:56:11 PM
npm http fetch GET https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz
npm http fetch 200 https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz
npm info lifecycle @earnest/eslint-config-es7@3.0.0~preinstall: @earnest/eslint-config-es7@3.0.0
npm info lifecycle lodash.pickby@4.6.0~preinstall: lodash.pickby@4.6.0
npm info lifecycle babel-eslint@6.1.2~preinstall: babel-eslint@6.1.2
npm WARN finalize Error: EBUSY: resource busy or locked, unlink '/usr/src/app/node_modules/@earnest/.eslint-config-es7.DELETE/index.js'
npm WARN finalize     at Error (native)
npm WARN finalize  { Error: EBUSY: resource busy or locked, unlink '/usr/src/app/node_modules/@earnest/.eslint-config-es7.DELETE/index.js'
npm WARN finalize     at Error (native)
npm WARN finalize   errno: -16,
npm WARN finalize   code: 'EBUSY',
npm WARN finalize   syscall: 'unlink',
npm WARN finalize   path: '/usr/src/app/node_modules/@earnest/.eslint-config-es7.DELETE/index.js' }
npm info linkStuff @earnest/eslint-config-es7@3.0.0
npm info linkStuff lodash.pickby@4.6.0
npm info linkStuff babel-eslint@6.1.2
npm info lifecycle @earnest/eslint-config-es7@3.0.0~install: @earnest/eslint-config-es7@3.0.0
npm info lifecycle lodash.pickby@4.6.0~install: lodash.pickby@4.6.0
npm info lifecycle babel-eslint@6.1.2~install: babel-eslint@6.1.2
npm info lifecycle @earnest/eslint-config-es7@3.0.0~postinstall: @earnest/eslint-config-es7@3.0.0
npm info lifecycle lodash.pickby@4.6.0~postinstall: lodash.pickby@4.6.0
npm info lifecycle babel-eslint@6.1.2~postinstall: babel-eslint@6.1.2
npm info lifecycle analyze-api@1.0.0~preinstall: analyze-api@1.0.0
npm info linkStuff analyze-api@1.0.0
npm info lifecycle analyze-api@1.0.0~install: analyze-api@1.0.0
npm info lifecycle analyze-api@1.0.0~postinstall: analyze-api@1.0.0
npm info lifecycle analyze-api@1.0.0~prepublish: analyze-api@1.0.0
analyze-api@1.0.0 /usr/src/app
+-- @earnest/eslint-config-es7@3.0.0
+-- babel-eslint@6.1.2
| `-- lodash.pickby@4.6.0
+-- UNMET PEER DEPENDENCY cheerio@0.19.x || 0.20.x
+-- UNMET PEER DEPENDENCY eslint@3.19.0
`-- UNMET PEER DEPENDENCY eslint-plugin-mocha@4.9.0

npm WARN optional Skipping failed optional dependency /chokidar/fsevents:
npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.1.1
npm WARN @earnest/eslint-config-es7@3.0.0 requires a peer of eslint-plugin-mocha@^3.0.0 but none was installed.
npm WARN @earnest/eslint-config-es7@3.0.0 requires a peer of eslint@^2.12.0 but none was installed.
npm WARN chai-enzyme@0.4.2 requires a peer of cheerio@0.19.x || 0.20.x but none was installed.
npm info ok
Usage: ./go <command> [sub-command]

Available commands are:
    migrate [cmd] Run database migrations
        development Run database migrations for dev
        test        Run database migrations for test
        staging     Run database migrations for staging
        production  Run database migrations for production
    load_fixtures [cmd] Loads fixtures
        development Load fixtures for dev
        test        Load fixtures for test
        staging     Load fixtures for staging
        production  Load fixtures for production
    create_migration Create a new correctly timestamped migration
    test [type]     Run tests
       unit         Run unit tests
       smoke [env]  Run smoke tests. Supported [env]: staging, production
    build [type]    Build docker image(s)
       all          Default, build everything
       dev          Build the development image
       prod         Build the production image
    compile         Compile source code
    push            Push docker image to Docker Hub.
       staging      Default, push image with 'latest' and version tag
       production   Push image with 'promoted' tag
    lint            Run lint on code
    deploy [env]    Deploy image from DockerHub via Rundeck
       staging      Deploy to staging
       production   Deploy to production
    start           Start service locally
       dev          Start dev service locally
       prod         Start prod service locally
    login [repo]    Login to service
       npm          Login to npm
       docker       Login to docker
    stop            Stop the local server
    exec            Execute any command inside the dev image
    coveralls       Send coverage report to Coveralls
    nuke            Destroy all containers and images associated with this project, node_modules, and any Babel transpiled code in the dist/ directory.
    help            Shows this help text
Executing command in container
^C⏎
➜  analyze-api git:(master) ✗ ./go exec bash
Executing command in container
Starting analyzeapi_node-modules_1
root@ed758c377b80:/usr/src/app# at node_modules/\@earnest/eslint-config-es7/package.json | jq .version
bash: at: command not found
root@ed758c377b80:/usr/src/app# cat node_modules/\@earnest/eslint-config-es7/package.json | jq .version
"4.0.2"
root@ed758c377b80:/usr/src/app# exit
exit
➜  analyze-api git:(master) ✗ ./go lint
Starting analyzeapi_node-modules_1
npm info it worked if it ends with ok
npm info using npm@3.8.6
npm info using node@v6.1.0
npm info lifecycle analyze-api@1.0.0~prelint: analyze-api@1.0.0
npm info lifecycle analyze-api@1.0.0~lint: analyze-api@1.0.0

> analyze-api@1.0.0 lint /usr/src/app
> eslint src test web web-test

Cannot read property 'range' of null
TypeError: Cannot read property 'range' of null
    at TokenStore.getTokenBefore (/usr/src/app/node_modules/eslint/lib/token-store/index.js:318:17)
    at EventEmitter.checkFunction (/usr/src/app/node_modules/eslint/lib/rules/generator-star-spacing.js:131:42)
    at emitOne (events.js:101:20)
    at EventEmitter.emit (events.js:188:7)
    at NodeEventGenerator.applySelector (/usr/src/app/node_modules/eslint/lib/util/node-event-generator.js:265:26)
    at NodeEventGenerator.applySelectors (/usr/src/app/node_modules/eslint/lib/util/node-event-generator.js:294:22)
    at NodeEventGenerator.enterNode (/usr/src/app/node_modules/eslint/lib/util/node-event-generator.js:308:14)
    at CodePathAnalyzer.enterNode (/usr/src/app/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:602:23)
    at CommentEventGenerator.enterNode (/usr/src/app/node_modules/eslint/lib/util/comment-event-generator.js:98:23)
    at Traverser.enter (/usr/src/app/node_modules/eslint/lib/eslint.js:929:36)

npm info lifecycle analyze-api@1.0.0~lint: Failed to exec lint script
npm ERR! Linux 4.9.13-moby
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "lint"
npm ERR! node v6.1.0
npm ERR! npm  v3.8.6
npm ERR! code ELIFECYCLE
npm ERR! analyze-api@1.0.0 lint: `eslint src test web web-test`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the analyze-api@1.0.0 lint script 'eslint src test web web-test'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the analyze-api package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     eslint src test web web-test
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs analyze-api
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls analyze-api
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /usr/src/app/npm-debug.log
➜  analyze-api git:(master) ✗

```
</details>