### PR TITLE
Update peer dependencies for Babel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# macOS system file
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
   "peerDependencies": {
     "babel-core": "^6.11.4",
     "babel-eslint": "^7.2.2",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-stage-3": "^6.11.0",
+    "babel-preset-env": "^1.6.1",
     "eslint-plugin-mocha": "^4.0.0",
     "eslint-plugin-babel": "^4.1.1",
     "eslint": "^3.19.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earnest/eslint-config-es7",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Earnest's ESLint config for ES7",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The presets ES2015 and stage-3 are no longer necessary.
Please see: http://babeljs.io/env

Tagging @meetearnest/platform folks as well as @pon and @akiellor just to ensure this is seen by folks outside of platform.